### PR TITLE
avoid reading sizes for non image files like pdf

### DIFF
--- a/src/buildUploadHook.ts
+++ b/src/buildUploadHook.ts
@@ -21,7 +21,7 @@ const getFilesToUpload: CollectionBeforeChangeHook = ({
       buffer: reqFile.data,
     },
   ];
-  if (data.sizes != null) {
+  if (data.mimeType.includes("image") && data.sizes != null) {
     Object.entries<FileData>(data.sizes).forEach(([key, sizeData]) => {
       files.push({
         filename: sizeData.filename,


### PR DESCRIPTION
When image sizes are given in config, if I try to upload non image files like *PDFs* or *Text* files I get errors. This pull request fixes that.