### PR TITLE
Fix error throwed while trying to save variant images

### DIFF
--- a/src/buildUploadHook.ts
+++ b/src/buildUploadHook.ts
@@ -23,11 +23,16 @@ const getFilesToUpload: CollectionBeforeChangeHook = ({
   ];
   if (data.mimeType?.includes('image') && data.sizes != null) {
     Object.entries<FileData>(data.sizes).forEach(([key, sizeData]) => {
-      files.push({
-        filename: sizeData.filename,
-        mimeType: data.mimeType,
-        buffer: req.payloadUploadSizes[key],
-      });
+      const buffer = req.payloadUploadSizes[key];
+      const { filename } = sizeData;
+
+      if (buffer !== undefined || filename !== null) {
+        files.push({
+          filename: sizeData.filename,
+          mimeType: data.mimeType,
+          buffer: req.payloadUploadSizes[key],
+        });
+      }
     });
   }
   return files;

--- a/src/buildUploadHook.ts
+++ b/src/buildUploadHook.ts
@@ -28,9 +28,9 @@ const getFilesToUpload: CollectionBeforeChangeHook = ({
 
       if (buffer !== undefined || filename !== null) {
         files.push({
-          filename: sizeData.filename,
+          buffer,
+          filename,
           mimeType: data.mimeType,
-          buffer: req.payloadUploadSizes[key],
         });
       }
     });

--- a/test/payload.config.ts
+++ b/test/payload.config.ts
@@ -49,6 +49,20 @@ export default buildConfig({
         },
         adminThumbnail: ({ doc }) =>
           `https://cdn.payloadcms.com/${doc.type}/${doc.filename}`,
+        imageSizes: [
+          {
+            name: 'small',
+            width: 400,
+            height: 400,
+            position: 'centre',
+          },
+          {
+            name: 'medium',
+            width: 800,
+            height: undefined,
+            position: 'centre',
+          },
+        ],
       },
     } as S3UploadCollectionConfig,
   ],


### PR DESCRIPTION
This PR fixes #16 

As long as I can see Payload doesn't generate a variant image when the original image is smaller than the variant size, so I validated that and return only the correct variants that can be uploaded.